### PR TITLE
Mss optimizations

### DIFF
--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -3,7 +3,7 @@
 extern crate ion;
 extern crate test;
 
-use ion::Ion;
+use ion::{Ion, Parser};
 use test::{Bencher, black_box};
 
 const DEF_HOTEL_ON_START: &str = include_str!("data/def_hotel_on_start.ion");
@@ -25,6 +25,58 @@ mod parse {
     fn section_on_end_of_ion(bencher: &mut Bencher) {
         bencher.iter(|| {
             let result = Ion::from_str(DEF_HOTEL_ON_END);
+            black_box(result.unwrap())
+        })
+    }
+
+    #[bench]
+    fn section_on_start_of_ion_tuned_parser(bencher: &mut Bencher) {
+        bencher.iter(|| {
+            let result = Parser::new(DEF_HOTEL_ON_START)
+                .with_row_capacity(12)
+                .with_array_capacity(4)
+                .with_section_capacity(1024)
+                .read();
+
+            black_box(result.unwrap())
+        })
+    }
+
+    #[bench]
+    fn section_on_start_of_ion_parser_no_prealloc(bencher: &mut Bencher) {
+        bencher.iter(|| {
+            let result = Parser::new(DEF_HOTEL_ON_START)
+                .with_row_capacity(0)
+                .with_array_capacity(0)
+                .with_section_capacity(0)
+                .read();
+
+            black_box(result.unwrap())
+        })
+    }
+
+    #[bench]
+    fn section_on_end_of_ion_tuned_parser(bencher: &mut Bencher) {
+        bencher.iter(|| {
+            let result = Parser::new(DEF_HOTEL_ON_END)
+                .with_row_capacity(12)
+                .with_array_capacity(4)
+                .with_section_capacity(1024)
+                .read();
+
+            black_box(result.unwrap())
+        })
+    }
+
+    #[bench]
+    fn section_on_end_of_ion_parser_no_prealloc(bencher: &mut Bencher) {
+        bencher.iter(|| {
+            let result = Parser::new(DEF_HOTEL_ON_END)
+                .with_row_capacity(0)
+                .with_array_capacity(0)
+                .with_section_capacity(0)
+                .read();
+
             black_box(result.unwrap())
         })
     }

--- a/src/ion/section.rs
+++ b/src/ion/section.rs
@@ -9,9 +9,13 @@ pub struct Section {
 
 impl Section {
     pub fn new() -> Section {
+        Self::with_capacity(1)
+    }
+
+    pub fn with_capacity(n: usize) -> Section {
         Section {
             dictionary: Dictionary::new(),
-            rows: Vec::new(),
+            rows: Vec::with_capacity(n),
         }
     }
 


### PR DESCRIPTION
The first commit adds optimizations to read slices (`slice opt`).
The second commit adds preallocation to all vectors created by parser (section rows, row cells, arrays) and adds small default preallocation (16 rows, 8 cells, 2 array items) which can be adjusted by the user.

Results:
```
test parse::section_on_end_of_ion
|           version            |               time              |
|------------------------------|---------------------------------|
| master                       | 5,575,801 ns/iter (+/- 262,817) |
| slice opt                    | 3,289,382 ns/iter (+/- 335,114) |
| slice opt + prealloc 0       | 3,555,159 ns/iter (+/- 215,086) |
| slice opt + prealloc default | 2,703,855 ns/iter (+/- 98,792)  |
| slice opt + prealloc tuned   | 2,545,149 ns/iter (+/- 84,132)  |


test parse::section_on_start_of_ion          |  |
|           version            |               time              |
|------------------------------|---------------------------------|
| master                       | 5,656,770 ns/iter (+/- 671,256) |
| slice opt                    | 3,275,692 ns/iter (+/- 140,807) |
| slice opt + prealloc 0       | 3,532,675 ns/iter (+/- 149,602) |
| slice opt + prealloc default | 2,753,021 ns/iter (+/- 89,196)  |
| slice opt + prealloc tuned   | 2,547,142 ns/iter (+/- 93,322)  |

test parse_filtered::section_on_end_of_ion
|           version            |             time             |
|------------------------------|------------------------------|
| master                       | 644,238 ns/iter (+/- 16,144) |
| slice opt                    | 639,601 ns/iter (+/- 16,530) |
| slice opt + prealloc default | 642,596 ns/iter (+/- 27,812) |

test parse_filtered::section_on_start_of_ion
|           version            |            time            |
|------------------------------|----------------------------|
| master                       | 19,653 ns/iter (+/- 1,050) |
| slice opt                    | 10,493 ns/iter (+/- 498)   |
| slice opt + prealloc default | 10,533 ns/iter (+/- 1,198) |
```