### PR TITLE
Fix issue with parser finishing early on dictionary entries with empty string ("") values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ion"
-version = "0.8.2"
+version = "0.8.3"
 description = "parse and process ion files"
 license = "MIT"
 homepage = "http://github.com/pzol/ion_rs"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -421,9 +421,8 @@ impl<'a> Parser<'a> {
             .next()
             .and_then(|(start, c)|
                 if c == ch {
-                    None
-                }
-                else {
+                    Some("")
+                } else {
                     Some(
                         self.cur
                             .find(|(_, c)| *c == ch)
@@ -538,6 +537,8 @@ mod tests {
                 first = "first"
                 # comment
                 second ="another"
+                whitespace = "  "
+                empty = ""
                 some_bool = true
 
                 ary = [ "col1", 2,"col3", false]
@@ -563,6 +564,8 @@ mod tests {
         assert_eq!(Some(Entry("first".to_owned(), Value::String("first".to_owned()))), p.next());
         assert_eq!(Some(Comment(" comment\n".to_owned())), p.next());
         assert_eq!(Some(Entry("second".to_owned(), Value::String("another".to_owned()))), p.next());
+        assert_eq!(Some(Entry("whitespace".to_owned(), Value::String("  ".to_owned()))), p.next());
+        assert_eq!(Some(Entry("empty".to_owned(), Value::String("".to_owned()))), p.next());
         assert_eq!(Some(Entry("some_bool".to_owned(), Value::Boolean(true))), p.next());
         assert_eq!(Some(
             Entry("ary".to_owned(),


### PR DESCRIPTION
Bench results:
```
test parse::section_on_end_of_ion                      ... bench:   4,667,271 ns/iter (+/- 308,264)
test parse::section_on_end_of_ion_parser_no_prealloc   ... bench:   5,487,083 ns/iter (+/- 398,070)
test parse::section_on_end_of_ion_tuned_parser         ... bench:   4,187,000 ns/iter (+/- 329,403)
test parse::section_on_start_of_ion                    ... bench:   4,678,676 ns/iter (+/- 354,955)
test parse::section_on_start_of_ion_parser_no_prealloc ... bench:   5,606,773 ns/iter (+/- 388,974)
test parse::section_on_start_of_ion_tuned_parser       ... bench:   4,235,297 ns/iter (+/- 417,736)
test parse_filtered::section_on_end_of_ion             ... bench:     495,618 ns/iter (+/- 55,009)
test parse_filtered::section_on_start_of_ion           ... bench:      20,121 ns/iter (+/- 2,330)
```

0.8.2
```test parse::section_on_end_of_ion                      ... bench:   4,801,201 ns/iter (+/- 2,910,579)
test parse::section_on_end_of_ion_parser_no_prealloc   ... bench:   5,713,055 ns/iter (+/- 2,509,126)
test parse::section_on_end_of_ion_tuned_parser         ... bench:   4,098,752 ns/iter (+/- 124,420)
test parse::section_on_start_of_ion                    ... bench:   4,679,484 ns/iter (+/- 153,387)
test parse::section_on_start_of_ion_parser_no_prealloc ... bench:   5,500,743 ns/iter (+/- 186,348)
test parse::section_on_start_of_ion_tuned_parser       ... bench:   4,092,629 ns/iter (+/- 252,915)
test parse_filtered::section_on_end_of_ion             ... bench:     498,269 ns/iter (+/- 134,679)
test parse_filtered::section_on_start_of_ion           ... bench:      20,390 ns/iter (+/- 2,109)
```

