### PR TITLE
Optimize parser a bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.8.6
+- Optimize parser a bit
+
 ## 0.8.5
 - Remove unused `slice_pattern` feature
 - Remove deprecated `try!` macro
@@ -9,7 +12,7 @@
 - Add filtering of sections when loading ion
 
 ## 0.8
-Drop unused / unfinished features
+- Drop unused / unfinished features
 - RustcDeserialize support
 - Validator (which wasn't working anyway)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ion"
-version = "0.8.5"
+version = "0.8.6"
 description = "parse and process ion files"
 license = "MIT"
 homepage = "http://github.com/pzol/ion_rs"


### PR DESCRIPTION
Hi,

I've been able to optimize the parser's performance by about 8% by dropping unnecessary clones and improving the peeking.

Previous bench:
```
test parse::section_on_end_of_ion                      ... bench:   2,140,022 ns/iter (+/- 96,911)
test parse::section_on_end_of_ion_parser_no_prealloc   ... bench:   2,722,251 ns/iter (+/- 125,368)
test parse::section_on_end_of_ion_tuned_parser         ... bench:   2,059,127 ns/iter (+/- 76,641)
test parse::section_on_start_of_ion                    ... bench:   2,162,467 ns/iter (+/- 184,089)
test parse::section_on_start_of_ion_parser_no_prealloc ... bench:   2,727,918 ns/iter (+/- 147,647)
test parse::section_on_start_of_ion_tuned_parser       ... bench:   2,050,619 ns/iter (+/- 128,850)
test parse_filtered::section_on_end_of_ion             ... bench:     439,933 ns/iter (+/- 13,307)
test parse_filtered::section_on_start_of_ion           ... bench:       8,536 ns/iter (+/- 299)
```
Current bench:
```
test parse::section_on_end_of_ion                      ... bench:   1,953,341 ns/iter (+/- 109,459)
test parse::section_on_end_of_ion_parser_no_prealloc   ... bench:   2,528,097 ns/iter (+/- 151,690)
test parse::section_on_end_of_ion_tuned_parser         ... bench:   1,894,989 ns/iter (+/- 174,711)
test parse::section_on_start_of_ion                    ... bench:   1,997,856 ns/iter (+/- 198,556)
test parse::section_on_start_of_ion_parser_no_prealloc ... bench:   2,569,013 ns/iter (+/- 323,789)
test parse::section_on_start_of_ion_tuned_parser       ... bench:   1,902,144 ns/iter (+/- 177,290)
test parse_filtered::section_on_end_of_ion             ... bench:     617,824 ns/iter (+/- 26,954)
test parse_filtered::section_on_start_of_ion           ... bench:       7,421 ns/iter (+/- 296)
```
Thanks,
Patryk :-)